### PR TITLE
Add QR code print functionality in ToolDetailsModal

### DIFF
--- a/frontend_web/src/components/ToolDetailsModal.jsx
+++ b/frontend_web/src/components/ToolDetailsModal.jsx
@@ -1,7 +1,78 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
+import { useReactToPrint } from "react-to-print";
+import printJS from "print-js";
 
 const ToolDetailsModal = ({ show, onClose, tool }) => {
     const [qrLoading, setQrLoading] = useState(true);
+    const qrPrintRef = useRef();
+
+    // Handle print via React-to-Print (for browser printing)
+    const handlePrint = useReactToPrint({
+        content: () => qrPrintRef.current,
+        documentTitle: `ToolTrack-QR-${tool?.tool_id || "code"}`,
+        pageStyle: `
+            @page {
+                size: 50mm 30mm;
+                margin: 0;
+            }
+            @media print {
+                body {
+                    margin: 0;
+                    padding: 0;
+                }
+                .qr-print-container {
+                    width: 50mm;
+                    height: 30mm;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    justify-content: center;
+                }
+                .qr-image {
+                    max-width: 26mm;
+                    max-height: 26mm;
+                }
+                .qr-label {
+                    font-size: 6pt;
+                    margin-top: 1mm;
+                    text-align: center;
+                }
+            }
+        `,
+    });
+
+    // Alternative method using Print-JS (better for some thermal printers)
+    const handleThermalPrint = () => {
+        // First download the QR image if it doesn't exist locally
+        fetch(tool.qr_code)
+            .then(response => response.blob())
+            .then(blob => {
+                const imageUrl = URL.createObjectURL(blob);
+                
+                // Use Print-JS to print the image with specific dimensions
+                printJS({
+                    printable: imageUrl,
+                    type: 'image',
+                    documentTitle: `Tool-${tool.tool_id}-QR`,
+                    imageStyle: 'width:26mm; max-width:26mm; max-height:26mm;',
+                    style: `
+                        @page {
+                            size: 50mm 30mm;
+                            margin: 0;
+                        }
+                    `,
+                    onLoadingEnd: () => {
+                        // Clean up the object URL after printing
+                        URL.revokeObjectURL(imageUrl);
+                    }
+                });
+            })
+            .catch(error => {
+                console.error("Error printing QR code:", error);
+                // Fallback to regular print method
+                handlePrint();
+            });
+    };
 
     if (!show || !tool) return null;
 
@@ -64,16 +135,42 @@ const ToolDetailsModal = ({ show, onClose, tool }) => {
                             </div>
                         </div>
 
-                        {/* Download button */}
+                        {/* Hidden element for printing */}
+                        <div style={{ display: "none" }}>
+                            <div ref={qrPrintRef} className="qr-print-container">
+                                <img 
+                                    src={tool.qr_code} 
+                                    alt="Printable QR" 
+                                    className="qr-image"
+                                />
+                                <div className="qr-label">
+                                    {tool.name} - ID: {tool.tool_id}
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Button Actions */}
                         {!qrLoading && (
-                            <div className="mt-4">
+                            <div className="mt-4 flex justify-center gap-3">
                                 <a
                                     href={tool.qr_code}
                                     download={`tool-${tool.tool_id}-qrcode.png`}
-                                    className="inline-block bg-teal-500 text-white text-sm px-4 py-2 rounded-md hover:bg-teal-600 transition"
+                                    className="inline-block bg-teal-500 text-white text-sm px-4 py-2 rounded-md hover:bg-teal-600 transition flex items-center justify-center min-w-[120px]"
                                 >
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                    </svg>
                                     Download QR Code
                                 </a>
+                                <button
+                                    onClick={handleThermalPrint}
+                                    className="inline-block bg-blue-500 text-white text-sm px-4 py-2 rounded-md hover:bg-blue-600 transition flex items-center justify-center min-w-[120px]"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+                                    </svg>
+                                    Print QR
+                                </button>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
Integrated two printing methods: React-to-Print for browser printing and Print-JS for compatibility with thermal printers. Adjusted styles and layout to support both methods, and included a hidden printable QR section in the modal.